### PR TITLE
add script to generate SBOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2024-11-18
+
+-   Add a new script: `pnpm run generate-sbom`.
+    The script generates a software bill of materials (SBOM) for the project that includes all production dependencies.
+    For more information, see the [relevant section in the Repository Guide](./docs/RepositoryGuide.md#pnpm-run-generate-sbom).
+
 ## 2024-09-27
 
 -   Migrate to [pnpm catalogs](https://pnpm.io/catalogs) for central dependencies.

--- a/docs/RepositoryGuide.md
+++ b/docs/RepositoryGuide.md
@@ -91,6 +91,16 @@ The report is written to `dist/license-report.html`.
 The source code for report generation is located in `support/create-license-report.ts`.
 Configuration happens via `support/license-config.yaml`.
 
+### `pnpm run generate-sbom`
+
+Generate a [CycloneDX](https://github.com/CycloneDX) SBOM (Software Bill of Materials) for the project.
+The generated sbom file is written to `dist/sbom.json`.
+The source code for report generation is located in `support/create-cyclonedx-sbom.ts`.
+Currently only JSON encoding is supported. The generated SBOM lists all components excluding devDependencies.
+
+> [!IMPORTANT]
+> This command depends on [Trivy](https://github.com/aquasecurity/trivy) and can only be executed if Trivy is [installed](https://aquasecurity.github.io/trivy/latest/getting-started/installation/) globally.
+
 ### `pnpm run preview`
 
 Starts a local http server serving the contents of the `dist/www` directory.

--- a/docs/RepositoryGuide.md
+++ b/docs/RepositoryGuide.md
@@ -98,6 +98,9 @@ The generated sbom file is written to `dist/sbom.json`.
 The source code for report generation is located in `support/create-cyclonedx-sbom.ts`.
 Currently only JSON encoding is supported. The generated SBOM lists all components excluding devDependencies.
 
+The script reads the project name (and, if present, the version) from the project root's `package.json` and embeds it into the SBOM.
+The current git revision (commit hash of `HEAD`) is also included.
+
 > [!IMPORTANT]
 > This command depends on [Trivy](https://github.com/aquasecurity/trivy) and can only be executed if Trivy is [installed](https://aquasecurity.github.io/trivy/latest/getting-started/installation/) globally.
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "build": "vite build",
         "build-docs": "typedoc",
         "build-license-report": "tsx ./support/create-license-report.ts ",
+        "generate-sbom": "tsx ./support/create-cyclonedx-sbom.ts",
         "preview": "vite preview",
         "lint": "eslint ./src ./support --ext .js,.ts,.jsx,.tsx,.mjs,.mts,.cjs,.cts",
         "eslint": "pnpm run lint",

--- a/support/create-cyclonedx-sbom.ts
+++ b/support/create-cyclonedx-sbom.ts
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
 import { execSync } from "child_process";
-import { readFileSync, writeFileSync, mkdirSync } from "fs";
-import { version } from "os";
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 
@@ -19,60 +18,58 @@ const THIS_DIR = resolve(dirname(fileURLToPath(import.meta.url)));
 const PACKAGE_DIR = resolve(THIS_DIR, "..");
 const PACKAGE_JSON_PATH = resolve(PACKAGE_DIR, "package.json");
 const OUTPUT_JSON_PATH = resolve(PACKAGE_DIR, "dist/sbom.json");
+const TEMP_DIR = resolve(PACKAGE_DIR, "node_modules/.temp");
 
 /**
- * additional property that is used to indicate the project's git revision
+ * Additional property that is used to indicate the project's git revision
  * see {@link https://github.com/CycloneDX/cyclonedx-property-taxonomy}
  */
 const GIT_REVISION_PROPERTY = "open-pioneer:git_revision";
 
 function main() {
     // Ensure directory exists, then write the report
-    mkdirSync(dirname(OUTPUT_JSON_PATH), {
-        recursive: true
-    });
+    mkdirSync(dirname(OUTPUT_JSON_PATH), { recursive: true });
+    mkdirSync(TEMP_DIR, { recursive: true });
+
     const sbom = createSBOM(); // Invoke trivy to generate sbom.
-    const projectInfo = readPackageJson(); 
+    const projectInfo = readPackageJson();
     const gitRevision = getGitRevision();
 
-    //merge additional info into sbom
+    // Add additional properties
     enhanceSBOM(sbom, projectInfo, gitRevision);
-    //override trivy output with enhanced sbom
+
+    // Save to disk
     saveSBOMFile(sbom);
 }
 
 /**
- * invoke trivy to create sbom for the project
+ * Invoke trivy to create sbom for the project
  */
 function createSBOM() {
-    //execute command to create sbom with trivy
-    execSync(`trivy fs --format cyclonedx -o ${OUTPUT_JSON_PATH} .`, { encoding: "utf-8" });
-    const sbomJson = JSON.parse(readFileSync(OUTPUT_JSON_PATH, "utf-8"));
-
+    const tempSbom = resolve(TEMP_DIR, "trivy-sbom.json");
+    execSync(`trivy fs --format cyclonedx -o ${tempSbom} .`, { encoding: "utf-8" });
+    const sbomJson = JSON.parse(readFileSync(tempSbom, "utf-8"));
     return sbomJson;
 }
 
 /**
- * parse additional information from project's package.json
+ * Parse additional information from project's package.json
  */
 function readPackageJson(): ProjectInfo {
     const packageJson = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf-8"));
 
     if (!packageJson["name"]) {
         throw new Error("required property `name` is missing");
-    } else if (!packageJson["type"]) {
-        throw new Error("required property `type` is missing");
     }
 
     return {
         name: packageJson["name"],
-        type: packageJson["type"],
         version: packageJson["version"]
     };
 }
 
 /**
- * execute git commant to retrieve git revision
+ * Execute git command to retrieve git revision
  */
 function getGitRevision(): string {
     const revision = execSync("git rev-parse HEAD", { encoding: "utf-8" }).trimEnd(); //use trim to remove trailing \n from stdout
@@ -80,38 +77,32 @@ function getGitRevision(): string {
 }
 
 /**
- * merge additional properties into sbom object
+ * Merge additional properties into sbom object
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function enhanceSBOM(sbom: any, projectInfo: ProjectInfo, gitRevision: string) {
     const sbomProjectMetadata = sbom["metadata"]["component"];
 
-    //do not use type from package.json because value `module` is not allowed (https://cyclonedx.org/schema/bom-1.6.schema.json definitions->component->properties->type)
-    //sbomProjectMetadata["type"] = projectInfo.type;
     sbomProjectMetadata["name"] = projectInfo.name;
     if (projectInfo.version) {
-        sbomProjectMetadata["version"] = version;
+        sbomProjectMetadata["version"] = projectInfo.version;
     }
 
-    const properties = sbomProjectMetadata["properties"]
-        ? (sbomProjectMetadata["properties"] as SBOMProperty[])
-        : [];
+    const properties = (sbomProjectMetadata["properties"] ?? []) as SBOMProperty[];
     properties.push({ name: GIT_REVISION_PROPERTY, value: gitRevision });
     sbomProjectMetadata["properties"] = properties;
 }
 
 /**
- * override original output file with updated vesion
+ * Write the final SBOM to the output path.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function saveSBOMFile(sbom: any) {
+function saveSBOMFile(sbom: unknown) {
     const sbomJson = JSON.stringify(sbom, undefined, 4);
     writeFileSync(OUTPUT_JSON_PATH, sbomJson, "utf-8");
 }
 
 interface ProjectInfo {
     name: string;
-    type: string;
     version?: string;
 }
 

--- a/support/create-cyclonedx-sbom.ts
+++ b/support/create-cyclonedx-sbom.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-import { execSync } from "child_process";
+import { execFileSync, execSync } from "child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
@@ -47,7 +47,9 @@ function main() {
  */
 function createSBOM() {
     const tempSbom = resolve(TEMP_DIR, "trivy-sbom.json");
-    execSync(`trivy fs --format cyclonedx -o ${tempSbom} .`, { encoding: "utf-8" });
+    execFileSync("trivy", ["fs", "--format", "cyclonedx", "-o", tempSbom, "."], {
+        encoding: "utf-8"
+    });
     const sbomJson = JSON.parse(readFileSync(tempSbom, "utf-8"));
     return sbomJson;
 }

--- a/support/create-cyclonedx-sbom.ts
+++ b/support/create-cyclonedx-sbom.ts
@@ -31,9 +31,8 @@ function main() {
     mkdirSync(dirname(OUTPUT_JSON_PATH), {
         recursive: true
     });
-    // Invoke pnpm to gather dependency information.
-    const sbom = createSBOM();
-    const projectInfo = readPackageJson();
+    const sbom = createSBOM(); // Invoke trivy to generate sbom.
+    const projectInfo = readPackageJson(); 
     const gitRevision = getGitRevision();
 
     //merge additional info into sbom

--- a/support/create-cyclonedx-sbom.ts
+++ b/support/create-cyclonedx-sbom.ts
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
+// SPDX-License-Identifier: Apache-2.0
+import { execSync } from "child_process";
+import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import { version } from "os";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+/**
+ * Generates SBOM (software bill of materials) using {@link https://github.com/aquasecurity/trivy Trivy}.
+ * The output file adheres to the {@link https://github.com/CycloneDX/specification CycloneDX specification} with JSON encoding.
+ *
+ * Warning:
+ * This script relies on Trivy and can only be executed if Trivy is installed globally.
+ */
+
+const THIS_DIR = resolve(dirname(fileURLToPath(import.meta.url)));
+
+const PACKAGE_DIR = resolve(THIS_DIR, "..");
+const PACKAGE_JSON_PATH = resolve(PACKAGE_DIR, "package.json");
+const OUTPUT_JSON_PATH = resolve(PACKAGE_DIR, "dist/sbom.json");
+
+/**
+ * additional property that is used to indicate the project's git revision
+ * see {@link https://github.com/CycloneDX/cyclonedx-property-taxonomy}
+ */
+const GIT_REVISION_PROPERTY = "open-pioneer:git_revision";
+
+function main() {
+    // Ensure directory exists, then write the report
+    mkdirSync(dirname(OUTPUT_JSON_PATH), {
+        recursive: true
+    });
+    // Invoke pnpm to gather dependency information.
+    const sbom = createSBOM();
+    const projectInfo = readPackageJson();
+    const gitRevision = getGitRevision();
+
+    //merge additional info into sbom
+    enhanceSBOM(sbom, projectInfo, gitRevision);
+    //override trivy output with enhanced sbom
+    saveSBOMFile(sbom);
+}
+
+/**
+ * invoke trivy to create sbom for the project
+ */
+function createSBOM() {
+    //execute command to create sbom with trivy
+    execSync(`trivy fs --format cyclonedx -o ${OUTPUT_JSON_PATH} .`, { encoding: "utf-8" });
+    const sbomJson = JSON.parse(readFileSync(OUTPUT_JSON_PATH, "utf-8"));
+
+    return sbomJson;
+}
+
+/**
+ * parse additional information from project's package.json
+ */
+function readPackageJson(): ProjectInfo {
+    const packageJson = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf-8"));
+
+    if (!packageJson["name"]) {
+        throw new Error("required property `name` is missing");
+    } else if (!packageJson["type"]) {
+        throw new Error("required property `type` is missing");
+    }
+
+    return {
+        name: packageJson["name"],
+        type: packageJson["type"],
+        version: packageJson["version"]
+    };
+}
+
+/**
+ * execute git commant to retrieve git revision
+ */
+function getGitRevision(): string {
+    const revision = execSync("git rev-parse HEAD", { encoding: "utf-8" }).trimEnd(); //use trim to remove trailing \n from stdout
+    return revision;
+}
+
+/**
+ * merge additional properties into sbom object
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function enhanceSBOM(sbom: any, projectInfo: ProjectInfo, gitRevision: string) {
+    const sbomProjectMetadata = sbom["metadata"]["component"];
+
+    //do not use type from package because value `module` is not allowed (https://cyclonedx.org/schema/bom-1.6.schema.json definitions->component->properties->type)
+    //sbomProjectMetadata["type"] = projectInfo.type;
+    sbomProjectMetadata["name"] = projectInfo.name;
+    if (projectInfo.version) {
+        sbomProjectMetadata["version"] = version;
+    }
+
+    const properties = sbomProjectMetadata["properties"]
+        ? (sbomProjectMetadata["properties"] as SBOMProperty[])
+        : [];
+    properties.push({ name: GIT_REVISION_PROPERTY, value: gitRevision });
+    sbomProjectMetadata["properties"] = properties;
+}
+
+/**
+ * override original output file with updated vesion
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function saveSBOMFile(sbom: any) {
+    const sbomJson = JSON.stringify(sbom, undefined, 4);
+    writeFileSync(OUTPUT_JSON_PATH, sbomJson, "utf-8");
+}
+
+interface ProjectInfo {
+    name: string;
+    type: string;
+    version?: string;
+}
+
+/**
+ * represents `property` type from CycloneDX specification
+ * key value pair that can be used to add information that is officially supported in the standard
+ */
+interface SBOMProperty {
+    name: string;
+    value: string;
+}
+
+try {
+    main();
+} catch (e) {
+    console.error("Fatal error", e);
+    process.exit(1);
+}

--- a/support/create-cyclonedx-sbom.ts
+++ b/support/create-cyclonedx-sbom.ts
@@ -10,7 +10,7 @@ import { fileURLToPath } from "url";
  * Generates SBOM (software bill of materials) using {@link https://github.com/aquasecurity/trivy Trivy}.
  * The output file adheres to the {@link https://github.com/CycloneDX/specification CycloneDX specification} with JSON encoding.
  *
- * Warning:
+ * Important:
  * This script relies on Trivy and can only be executed if Trivy is installed globally.
  */
 
@@ -86,7 +86,7 @@ function getGitRevision(): string {
 function enhanceSBOM(sbom: any, projectInfo: ProjectInfo, gitRevision: string) {
     const sbomProjectMetadata = sbom["metadata"]["component"];
 
-    //do not use type from package because value `module` is not allowed (https://cyclonedx.org/schema/bom-1.6.schema.json definitions->component->properties->type)
+    //do not use type from package.json because value `module` is not allowed (https://cyclonedx.org/schema/bom-1.6.schema.json definitions->component->properties->type)
     //sbomProjectMetadata["type"] = projectInfo.type;
     sbomProjectMetadata["name"] = projectInfo.name;
     if (projectInfo.version) {
@@ -117,7 +117,7 @@ interface ProjectInfo {
 
 /**
  * represents `property` type from CycloneDX specification
- * key value pair that can be used to add information that is officially supported in the standard
+ * key value pair that can be used to add information
  */
 interface SBOMProperty {
     name: string;


### PR DESCRIPTION
Add support script to generate SBOM using the CycloneDX standard. The scripts depends on Trivy.


example output for Trails Starter project:
[sbom.json](https://github.com/user-attachments/files/17460547/sbom.json)

It was tested to parse the example output with [DependencyTrack](https://owasp.org/www-project-dependency-track/). The packages were displayed in DependencyTrack and outdated versions were marked.

[issue](open-pioneer/trails-build-tools#62)

