### PR TITLE
Fix deprecated eslint rule

### DIFF
--- a/typedoc.config.cjs
+++ b/typedoc.config.cjs
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2023 Open Pioneer project (https://github.com/open-pioneer)
 // SPDX-License-Identifier: Apache-2.0
-/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 const { sync: fastGlobSync } = require("fast-glob");
 const { dirname } = require("path");
 const DEFAULT_HIGHLIGHT_LANGS = require("typedoc").OptionDefaults.highlightLanguages;


### PR DESCRIPTION
Pre-commit script failed, caused by deprecated eslint rule "no-var-requires".

See https://typescript-eslint.io/rules/no-var-requires/

![2024-11-28 09_08_46-typedoc config cjs - trails-starter - Visual Studio Code](https://github.com/user-attachments/assets/efe49cd7-0f13-40b1-8a49-8e81ad9a34b0)

After the rule has been replaced the Pre-commit script was successful.

![2024-11-28 09_15_50-typedoc config cjs - trails-starter - Visual Studio Code](https://github.com/user-attachments/assets/edc62b3e-cb51-449a-a506-c727bf671baa)

Replace

`/* eslint-disable @typescript-eslint/no-var-requires */`

with

`/* eslint-disable @typescript-eslint/no-require-imports */`

Other Open Pioneer repos are also effected: [no-var-requires](https://github.com/search?q=org%3Aopen-pioneer%20no-var-requires&type=code).