### PR TITLE
Update Format.JS links

### DIFF
--- a/docs/internals/Design_Phase1.md
+++ b/docs/internals/Design_Phase1.md
@@ -127,7 +127,7 @@ Reasons for that choice include:
 
 [FormatJS](https://formatjs.io/) was chosen as the i18n framework for our technology stack.
 It it well maintained, used by a large number of projects and has a well designed API.
-The central interface exposed by FormatJS is the `intl` object (see [API](https://formatjs.io/docs/react-intl/api/#intlshape)).
+The central interface exposed by FormatJS is the `intl` object (see [API](https://formatjs.github.io/docs/react-intl/api/#intlshape)).
 
 ## Implementation strategy
 

--- a/docs/reference/I18nFormat.md
+++ b/docs/reference/I18nFormat.md
@@ -46,7 +46,7 @@ overrides:
 ## FormatJS
 
 At runtime, all messages are made available on an `intl` object provided by the [FormatJS Library](https://formatjs.io/).
-Message templates can use the [message syntax](https://formatjs.io/docs/core-concepts/icu-syntax) supported by FormatJS.
+Message templates can use the [message syntax](https://formatjs.github.io/docs/core-concepts/icu-syntax) supported by FormatJS.
 
 Use the `formatMessage` method on an `intl` object to format an i18n message:
 
@@ -61,4 +61,4 @@ As an extension, it also possible to format React nodes using the `formatRichMes
 const message = intl.formatRichMessage({ id: "greeting" }, { name: <UserName /> });
 ```
 
-FormatJS also provides facilities to format numbers, dates etc. in the appropriate locale, see also [Documentation](https://formatjs.io/docs/intl#intlshape).
+FormatJS also provides facilities to format numbers, dates etc. in the appropriate locale, see also [Documentation](https://formatjs.github.io/docs/intl/#intlshape).

--- a/docs/research/i18n_overview.md
+++ b/docs/research/i18n_overview.md
@@ -54,12 +54,12 @@
 
 ### FormatJS
 
-- first-party React integration, [react-intl](https://formatjs.io/docs/react-intl/)
+- first-party React integration, [react-intl](https://formatjs.github.io/docs/react-intl/)
 - first-class ICU Message Format support
 - no build-in translation file loading and user language detection
-- good tooling ([CLI](https://formatjs.io/docs/tooling/cli),[eslint-plugin](https://https://formatjs.io/docs/tooling/linter),...)
-- good [TMS integration](https://formatjs.io/docs/getting-started/message-extraction/#translation-management-system-tms-integration)
-- support for [pre-compiled messages](https://formatjs.io/docs/guides/advanced-usage) into AST, reduced react-intl without parser (40% smaller)
+- good tooling ([CLI](https://formatjs.github.io/docs/tooling/cli/),[eslint-plugin](https://formatjs.github.io/docs/tooling/linter),...)
+- good [TMS integration](https://formatjs.github.io/docs/getting-started/message-extraction/#translation-management-system-tms-integration)
+- support for [pre-compiled messages](https://formatjs.github.io/docs/guides/advanced-usage/) into AST, reduced react-intl without parser (40% smaller)
 - react-intl: Internationalizing can be applied only in view layer such as React.Component -> [react-intl-universal](https://github.com/alibaba/react-intl-universal) for Vanilla JS
 - well established community
 

--- a/docs/tutorials/HowToTranslateAnApp.md
+++ b/docs/tutorials/HowToTranslateAnApp.md
@@ -192,7 +192,7 @@ function ExampleStack() {
 }
 ```
 
-With plural support we can output different text depending on a count value (see [Link](https://formatjs.io/docs/core-concepts/icu-syntax/#plural-format)).
+With plural support we can output different text depending on a count value (see [Link](https://formatjs.github.io/docs/core-concepts/icu-syntax/#plural-format)).
 We will use a RadioGroup to change the count value in our example:
 
 ```tsx
@@ -267,7 +267,7 @@ function ExampleStack() {
 }
 ```
 
-With selection support we can output different text depending on a set of given values (see [Link](https://formatjs.io/docs/core-concepts/icu-syntax/#select-format)).
+With selection support we can output different text depending on a set of given values (see [Link](https://formatjs.github.io/docs/core-concepts/icu-syntax/#select-format)).
 In our example we will change the title depending on a gender selection.
 We will use a text input for name and a RadioGroup for gender selection:
 
@@ -367,7 +367,7 @@ function ExampleStack() {
 }
 ```
 
-With `formatNumber` we can not only format numbers locale specific, but also use units and currencies (see [Link](https://formatjs.io/docs/react-intl/api#formatnumber)).
+With `formatNumber` we can not only format numbers locale specific, but also use units and currencies (see [Link](https://formatjs.github.io/docs/react-intl/api/#formatnumber)).
 In our example we will have a number input and an output with different forms of unit and currency:
 
 ```tsx
@@ -539,8 +539,8 @@ messages:
 
 Add the defined keys to all yaml files.
 
-We pass the `value` with `DateTimeFormatOptions` to `intl.formatDate` (see [Link](https://formatjs.io/docs/react-intl/api#formatdate))
-and with `RelativeTimeFormatOptions` to `intl.formatRelativeTime` (see [Link](https://formatjs.io/docs/react-intl/api#formatrelativetime))
+We pass the `value` with `DateTimeFormatOptions` to `intl.formatDate` (see [Link](https://formatjs.github.io/docs/react-intl/api/#formatdate))
+and with `RelativeTimeFormatOptions` to `intl.formatRelativeTime` (see [Link](https://formatjs.github.io/docs/react-intl/api/#formatrelativetime))
 
 In result, we see our selected formatted datetime and the relative time between now and the selected datetime.
 
@@ -758,6 +758,6 @@ For more information refer to the API of the `core-packages` `runtime` package.
 
 ## Further reading
 
-- [FormatJS Documentation](https://formatjs.io/docs/getting-started/installation)
-- [Message syntax](https://formatjs.io/docs/core-concepts/icu-syntax)
-- [Intl Reference](https://formatjs.io/docs/react-intl/api#intlshape) (interface `IntlFormatters`)
+- [FormatJS Documentation](https://formatjs.github.io/docs/getting-started/installation/)
+- [Message syntax](https://formatjs.github.io/docs/core-concepts/icu-syntax/)
+- [Intl Reference](https://formatjs.github.io/docs/react-intl/api/#intlshape) (interface `IntlFormatters`)


### PR DESCRIPTION
The documentation site had moved from `https://formatjs.io/docs/` to `https://formatjs.github.io/docs/`. This PR updates the links to this site.